### PR TITLE
add build script as stopgap until we setup CI

### DIFF
--- a/script/build_and_push.sh
+++ b/script/build_and_push.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+pip install --require-virtualenv . && \
+docker build . -t gcr.io/moz-fx-data-experiments/auto_sizing:latest && \
+docker push gcr.io/moz-fx-data-experiments/auto_sizing:latest && \
+echo
+echo "Done."
+echo
+


### PR DESCRIPTION
Script builds/installs `auto-sizing` tool locally, builds/tags the docker image, and pushes the docker image to the repo. This is a stopgap because ideally this would happen automatically via CI, but it is an useful tool in the meantime.

We should probably delete (or modify) this script once we have CI setup so that we don't accidentally push docker images on the `latest` tag that have not been tested/merged into main.