### PR TITLE
add 30 day expiration for successful argo workflows

### DIFF
--- a/auto_sizing/workflows/run.yaml
+++ b/auto_sizing/workflows/run.yaml
@@ -4,6 +4,8 @@ metadata:
   generateName: auto-sizing-
 spec:
   entrypoint: auto-sizing
+  ttl-strategy:
+    secondsAfterSuccess: 2592000 # delete workflows automatically after 30 days
   arguments:
     parameters:
     - name: targets  # set dynamically when workflow gets deployed


### PR DESCRIPTION
Jetstream added this to remove old images that were just cluttering the console and making the Argo UI super slow. Adding here as well so that the auto_sizing images get removed periodically as well.