### PR TITLE
add circle config and remove stopgap build script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,51 @@ version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.1
 
+jobs:
+  build:
+    docker:
+    - image: python:3.10
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+          # when lock files change, use increasingly general patterns to restore cache
+          - &cache_key
+            python-packages-v1-{{ .Branch }}-{{ checksum "requirements.in" }}-{{ checksum "requirements.txt" }}
+          - python-packages-v1-{{ .Branch }}-{{ checksum "requirements.in" }}-
+          - python-packages-v1-{{ .Branch }}-
+          - python-packages-v1-
+    - &build
+      run:
+        name: Build
+        command: |
+          python3.10 -m venv venv/
+          venv/bin/pip install --progress-bar off --upgrade -r requirements.txt
+    - run:
+        name: PyTest
+        command: venv/bin/pytest --black --ignore=auto_sizing/tests/integration/
+    - run:
+        name: flake8
+        command: venv/bin/flake8 auto_sizing
+    - run:
+        name: isort
+        command: venv/bin/isort --check auto_sizing
+    - run:
+        name: Mypy
+        command: venv/bin/mypy auto_sizing
+    - save_cache:
+        paths:
+        - venv/
+        key: *cache_key
+
 workflows:
   build-and-deploy:
     jobs:
+      - build
       - gcp-gcr/build-and-push-image:
-          image: auto_sizing
+          requires:
+            - build
+          image: jetstream
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           requires:
             - build
-          image: jetstream
+          image: auto_sizing
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ pip install .
 ```
 
 ## Production Build
-In the future, this will be done automatically via CI. For now, run `script/build_and_push.sh` to build the docker image and push it to GCR for use by the cluster.
-- **Note**: The image must be built for x86 (`linux/amd64`) architecture.
+Docker images are built automatically via CI (see `.circleci/config.yml`) for new commits to `main`.
 
 ## Deployment
 Deployment is done similarly to [Jetstream](github.com/mozilla/jetstream): Docker container is built and pushed to GCR, where Argo manages orchestration of tasks in GKE. This tool leverages the existing Jetstream Argo cluster.

--- a/script/build_and_push.sh
+++ b/script/build_and_push.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-pip install --require-virtualenv . && \
-docker build . -t gcr.io/moz-fx-data-experiments/auto_sizing:latest && \
-docker push gcr.io/moz-fx-data-experiments/auto_sizing:latest && \
-echo
-echo "Done."
-echo
-


### PR DESCRIPTION
This basically takes what Jetstream does and removes the unnecessary bits (integration tests because we don't have them (yet?),                  and PyPi deployment because we don't need that).

Also updates the README to reflect that builds occur automatically and removes the manual stopgap build script to avoid accidentally overwriting the docker image in GCR.