### PR TITLE
Separate metrics and parameters JSON entries

### DIFF
--- a/auto_sizing/size_calculation.py
+++ b/auto_sizing/size_calculation.py
@@ -103,7 +103,8 @@ class SizeCalculation:
             power=parameters["power"],
         )
 
-        result_dict = {
+        result_dict = {"parameters": parameters}
+        result_dict["metrics"] = {
             key: {
                 "number_of_clients_targeted": res[key]["number_of_clients_targeted"],
                 "sample_size_per_branch": res[key]["sample_size_per_branch"],
@@ -111,7 +112,6 @@ class SizeCalculation:
             }
             for key in res.keys()
         }
-        result_dict["parameters"] = parameters
 
         return result_dict
 

--- a/auto_sizing/size_calculation.py
+++ b/auto_sizing/size_calculation.py
@@ -95,7 +95,7 @@ class SizeCalculation:
 
     def calculate_sample_sizes(
         self, metrics_table: DataFrame, parameters: Dict[str, float]
-    ) -> Dict[str, Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         res = z_or_t_ind_sample_size_calc(
             df=metrics_table,
             metrics_list=self.config.metric_list,
@@ -103,14 +103,17 @@ class SizeCalculation:
             power=parameters["power"],
         )
 
-        result_dict = {"parameters": parameters}
-        result_dict["metrics"] = {
+        metrics_results = {
             key: {
                 "number_of_clients_targeted": res[key]["number_of_clients_targeted"],
                 "sample_size_per_branch": res[key]["sample_size_per_branch"],
                 "population_percent_per_branch": res[key]["population_percent_per_branch"],
             }
             for key in res.keys()
+        }
+        result_dict = {
+            "parameters": parameters,
+            "metrics": metrics_results,
         }
 
         return result_dict


### PR DESCRIPTION
This changes the structure of the JSON results for auto-sizing runs. Previous results had the `parameters` and minimum sample sizes for each metric under the same key; this change separates the metrics results into dict under a `metrics` key and a separate key for the parameters:
`"sample_sizes": {
      "Power0.8EffectSize0.005": {
        "metrics": {
          "active_hours": {
            "number_of_clients_targeted": 472111,
            "sample_size_per_branch": 4079634.9467410482,
            "population_percent_per_branch": 864.1262217446847
          },
          "search_count": {
            "number_of_clients_targeted": 472111,
            "sample_size_per_branch": 5206189.8269372685,
            "population_percent_per_branch": 1102.7469868181993
          },
          "days_of_use": {
            "number_of_clients_targeted": 472111,
            "sample_size_per_branch": 885439.5434486775,
            "population_percent_per_branch": 187.54901780485469
          }
        },
        "parameters": {
          "power": 0.8,
          "effect_size": 0.005
        }
      },`