### PR TITLE
fix #27: Remove min Fx version from targeting

### DIFF
--- a/auto_sizing/data/manifest.toml
+++ b/auto_sizing/data/manifest.toml
@@ -1,239 +1,47 @@
 [argo_target_0]
 app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_1]
 app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
 
 [argo_target_2]
 app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_3]
 app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
 
 [argo_target_4]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+app_id = "firefox_ios"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_5]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+app_id = "firefox_ios"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
 
 [argo_target_6]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+app_id = "firefox_ios"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_7]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+app_id = "firefox_ios"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
 
 [argo_target_8]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+app_id = "fenix"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_9]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+app_id = "fenix"
+target_recipe = "{\"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
 
 [argo_target_10]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
+app_id = "fenix"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
 
 [argo_target_11]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_12]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_13]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_14]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_15]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_16]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_17]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_18]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_19]
-app_id = "firefox_desktop"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_20]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_21]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_22]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_23]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_24]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_25]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_26]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_27]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_28]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_29]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_30]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_31]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_32]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_33]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_34]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_35]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_36]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_37]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_38]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_39]
-app_id = "firefox_ios"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_40]
 app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_41]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_42]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_43]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"108\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_44]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_45]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_46]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_47]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"107\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_48]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_49]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_50]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_51]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"106\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_52]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_53]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_54]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_55]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"105\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_56]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_57]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
-
-[argo_target_58]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"new\"}"
-
-[argo_target_59]
-app_id = "fenix"
-target_recipe = "{\"minimum_version\": \"104\", \"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"
+target_recipe = "{\"locale\": \"('EN-US', 'EN-CA', 'EN-GB')\", \"release_channel\": \"release\", \"country\": \"US\", \"user_type\": \"existing\"}"

--- a/auto_sizing/data/target_lists.toml
+++ b/auto_sizing/data/target_lists.toml
@@ -1,5 +1,4 @@
 [targets]
-minimum_version = ["108", "107", "106", "105", "104"]
 locale = ["('EN-US')", "('EN-US', 'EN-CA', 'EN-GB')"]
 release_channel = ["release"]
 country = ["US"]

--- a/auto_sizing/export_json.py
+++ b/auto_sizing/export_json.py
@@ -95,14 +95,12 @@ def aggregate_and_reupload(
             locale = recipe.get("locale")
             country = recipe.get("country")
             new_or_existing = recipe.get("user_type")
-            minimum_version = recipe.get("minimum_version")
             recipe_info = {
                 "app_id": app_id,
                 "channel": channel,
                 "locale": locale,
                 "country": country,
                 "new_or_existing": new_or_existing,
-                "minimum_version": minimum_version,
             }
             results = {
                 "target_recipe": recipe_info,
@@ -110,7 +108,7 @@ def aggregate_and_reupload(
             }
 
             # target_key should be an easy lookup for relevant sizing
-            # {app_id}:{channel}:{locale}:{country}:{minimum_version}
+            # {app_id}:{channel}:{locale}:{country}
 
             target_key = f"{app_id}"
             if channel:
@@ -122,14 +120,12 @@ def aggregate_and_reupload(
                 target_key += f":{sorted_locale}".replace(" ", "")
             if country:
                 target_key += f":{country}"
-            if minimum_version:
-                target_key += f":{minimum_version}"
 
             if target_key not in agg_json:
                 agg_json[target_key] = {}
             agg_json[target_key][new_or_existing] = results
 
-            # final structure looks like: (TODO: remove minimum_version)
+            # final structure looks like:
             """
             {
                 "firefox_desktop:release:['EN-CA','EN-US']:US:110": {

--- a/auto_sizing/targets.py
+++ b/auto_sizing/targets.py
@@ -119,14 +119,12 @@ class SegmentsList:
     def _desktop_sql(self, target: Dict[str, str]) -> str:
         clients_daily_sql = """
         COALESCE(LOGICAL_OR(
-        (mozfun.norm.truncate_version(app_display_version, 'major') >= {version}) AND
         (normalized_channel = '{channel}') AND
         (UPPER(locale) in {locale}) AND
         (country = '{country}')
         )
         )
         """.format(
-            version=target["minimum_version"],
             channel=target["release_channel"],
             locale=target["locale"],
             country=target["country"],
@@ -182,14 +180,12 @@ class SegmentsList:
     def _ios_sql(self, target: Dict) -> str:
         clients_daily_sql = """
         COALESCE(LOGICAL_OR(
-        (mozfun.norm.truncate_version(app_display_version, 'major') >= {version}) AND
         (normalized_channel = '{channel}') AND
         (UPPER(locale) in {locale}) AND
         (country = '{country}')
         )
         )
         """.format(
-            version=target["minimum_version"],
             channel=target["release_channel"],
             locale=target["locale"],
             country=target["country"],
@@ -244,14 +240,12 @@ class SegmentsList:
     def _fenix_sql(self, target: Dict) -> str:
         clients_daily_sql = """
         COALESCE(LOGICAL_OR(
-        (mozfun.norm.truncate_version(app_display_version, 'major') >= {version}) AND
         (normalized_channel = '{channel}') AND
         (UPPER(locale) in {locale}) AND
         (country = '{country}')
         )
         )
         """.format(
-            version=target["minimum_version"],
             channel=target["release_channel"],
             locale=target["locale"],
             country=target["country"],


### PR DESCRIPTION
Removes the minimum version from targeting recipes. This also removes the minimum version from the results JSON, so these changes shouldn't be merged until changes are made to ingestion to remove the key.