### PR TITLE
add source column for logging

### DIFF
--- a/auto_sizing/cli.py
+++ b/auto_sizing/cli.py
@@ -10,6 +10,7 @@ import click
 import pytz
 import toml
 from jetstream.argo import submit_workflow
+from jetstream.logging import LOG_SOURCE
 
 from .errors import NoConfigFileException
 from .export_json import aggregate_and_reupload
@@ -236,7 +237,11 @@ log_table_id_option = click.option(
     "--log_table_id", "--log-table-id", default="logs", help="Table to write logs to"
 )
 log_source = click.option(
-    "--log-source", "--log_source", default="SIZING", help="Source column for logs"
+    "--log-source",
+    "--log_source",
+    default=LOG_SOURCE.SIZING,
+    type=LOG_SOURCE,
+    help="Source column for logs",
 )
 
 

--- a/auto_sizing/cli.py
+++ b/auto_sizing/cli.py
@@ -62,16 +62,6 @@ class ArgoExecutorStrategy:
         self,
         worklist: Iterable[SizingConfiguration],
     ):
-        # experiments_config: Dict[str, List[str]] = {}
-        # for config in worklist:
-        #     experiments_config.setdefault(config.experiment.normandy_slug, []).append(
-        #         # date.strftime("%Y-%m-%d")
-        #     )
-
-        # experiments_config_list = [
-        #     {"slug": slug, "dates": dates} for slug, dates in experiments_config.items()
-        # ]
-
         targets_list = [{"slug": config.target_slug} for config in worklist]
         logger.debug(f"TARGETS LIST: {targets_list}")
 
@@ -245,6 +235,9 @@ log_dataset_id_option = click.option(
 log_table_id_option = click.option(
     "--log_table_id", "--log-table-id", default="logs", help="Table to write logs to"
 )
+log_source = click.option(
+    "--log-source", "--log_source", default="SIZING", help="Source column for logs"
+)
 
 
 @click.group()
@@ -252,6 +245,7 @@ log_table_id_option = click.option(
 @log_dataset_id_option
 @log_table_id_option
 @click.option("--log_to_bigquery", "--log-to-bigquery", is_flag=True, default=False)
+@log_source
 @click.pass_context
 def cli(
     ctx,
@@ -259,12 +253,14 @@ def cli(
     log_dataset_id,
     log_table_id,
     log_to_bigquery,
+    log_source,
 ):
     log_config = LogConfiguration(
         log_project_id,
         log_dataset_id,
         log_table_id,
         log_to_bigquery,
+        log_source,
     )
     log_config.setup_logger()
     ctx.ensure_object(dict)

--- a/auto_sizing/cli.py
+++ b/auto_sizing/cli.py
@@ -259,8 +259,8 @@ def cli(
         log_project_id,
         log_dataset_id,
         log_table_id,
-        log_to_bigquery,
         log_source,
+        log_to_bigquery,
     )
     log_config.setup_logger()
     ctx.ensure_object(dict)

--- a/auto_sizing/logging/__init__.py
+++ b/auto_sizing/logging/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 import attr
 import dask.distributed
 from distributed.diagnostics.plugin import WorkerPlugin
+from jetstream.logging import LOG_SOURCE
 
 from .bigquery_log_handler import BigQueryLogHandler
 
@@ -17,7 +18,7 @@ class LogConfiguration:
     log_table_id: Optional[str]
     log_to_bigquery: bool = False
     capacity: int = 50
-    source: str = "SIZING"
+    source: str = LOG_SOURCE.SIZING
 
     def setup_logger(self, client=None):
         logging.basicConfig(

--- a/auto_sizing/logging/__init__.py
+++ b/auto_sizing/logging/__init__.py
@@ -31,9 +31,9 @@ class LogConfiguration:
                 self.log_project_id,
                 self.log_dataset_id,
                 self.log_table_id,
+                self.source,
                 client,
                 self.capacity,
-                self.source,
             )
             bigquery_handler.setLevel(logging.WARNING)
             logger.addHandler(bigquery_handler)

--- a/auto_sizing/logging/__init__.py
+++ b/auto_sizing/logging/__init__.py
@@ -17,6 +17,7 @@ class LogConfiguration:
     log_table_id: Optional[str]
     log_to_bigquery: bool = False
     capacity: int = 50
+    source: str = "SIZING"
 
     def setup_logger(self, client=None):
         logging.basicConfig(
@@ -27,7 +28,12 @@ class LogConfiguration:
 
         if self.log_to_bigquery:
             bigquery_handler = BigQueryLogHandler(
-                self.log_project_id, self.log_dataset_id, self.log_table_id, client, self.capacity
+                self.log_project_id,
+                self.log_dataset_id,
+                self.log_table_id,
+                client,
+                self.capacity,
+                self.source,
             )
             bigquery_handler.setLevel(logging.WARNING)
             logger.addHandler(bigquery_handler)

--- a/auto_sizing/logging/bigquery_log_handler.py
+++ b/auto_sizing/logging/bigquery_log_handler.py
@@ -13,9 +13,9 @@ class BigQueryLogHandler(BufferingHandler):
         project_id: str,
         dataset_id: str,
         table_id: str,
+        source: str,
         client: Optional[bigquery.Client] = None,
         capacity=50,
-        source: str = "SIZING",
     ):
         self.project_id = project_id
         self.dataset_id = dataset_id

--- a/auto_sizing/logging/bigquery_log_handler.py
+++ b/auto_sizing/logging/bigquery_log_handler.py
@@ -15,6 +15,7 @@ class BigQueryLogHandler(BufferingHandler):
         table_id: str,
         client: Optional[bigquery.Client] = None,
         capacity=50,
+        source: str = "SIZING",
     ):
         self.project_id = project_id
         self.dataset_id = dataset_id
@@ -22,6 +23,7 @@ class BigQueryLogHandler(BufferingHandler):
         self.client = client
         if client is None:
             self.client = bigquery.Client(project_id)
+        self.source = source
 
         super().__init__(capacity)
 
@@ -32,6 +34,7 @@ class BigQueryLogHandler(BufferingHandler):
                 "timestamp": datetime.datetime.fromtimestamp(record.created).strftime(
                     "%Y-%m-%d %H:%M:%S"
                 ),
+                "source": self.source if not hasattr(record, "source") else record.source,
                 "experiment": None if not hasattr(record, "experiment") else record.experiment,
                 "metric": None if not hasattr(record, "metric") else record.metric,
                 "statistic": None if not hasattr(record, "statistic") else record.statistic,

--- a/requirements.in
+++ b/requirements.in
@@ -163,7 +163,7 @@ mozanalysis==2023.5.3
     #   mozilla-auto-sizing
     #   mozilla-jetstream
     # via -r -
-mozilla-jetstream==2023.6.1
+mozilla-jetstream==2023.8.1
     # via mozilla-auto-sizing
 mozilla-metric-config-parser==2023.6.7
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -363,6 +363,7 @@ google-api-core[grpc]==2.11.1 \
     --hash=sha256:d92a5a92dc36dd4f4b9ee4e55528a90e432b059f93aee6ad857f9de8cc7ae94a
     # via
     #   -r requirements.in
+    #   google-cloud-artifact-registry
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-container
@@ -376,6 +377,10 @@ google-auth==2.22.0 \
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
+google-cloud-artifact-registry==1.8.3 \
+    --hash=sha256:9206d2c0647939b90c6eea78a7878f5e7c65eee467d2761e182394d4b30f6521 \
+    --hash=sha256:c6b82d5123671cbca5e2a666732e1eb305ab8e25603616d3d6c0e622b19d2de9
+    # via mozilla-jetstream
 google-cloud-bigquery==3.11.4 \
     --hash=sha256:5fa7897743a0ed949ade25a0942fc9e7557d8fce307c6f8a76d1b604cf27f1b1 \
     --hash=sha256:697df117241a2283bcbb93b21e10badc14e51c9a90800d2a7e1a3e1c7d842974
@@ -489,13 +494,18 @@ google-resumable-media==2.5.0 \
     #   -r requirements.in
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos==1.60.0 \
+googleapis-common-protos[grpc]==1.60.0 \
     --hash=sha256:69f9bbcc6acde92cab2db95ce30a70bd2b81d20b12eff3f1aabaffcbe8a93918 \
     --hash=sha256:e73ebb404098db405ba95d1e1ae0aa91c3e15a71da031a2eeb6b2e23e7bc3708
     # via
     #   -r requirements.in
     #   google-api-core
+    #   grpc-google-iam-v1
     #   grpcio-status
+grpc-google-iam-v1==0.12.6 \
+    --hash=sha256:2bc4b8fdf22115a65d751c9317329322602c39b7c86a289c9b72d228d960ef5f \
+    --hash=sha256:5c10f3d8dc2d88678ab1a9b0cb5482735c5efee71e6c0cd59f872eef22913f5c
+    # via google-cloud-artifact-registry
 grpcio==1.56.2 \
     --hash=sha256:06e84ad9ae7668a109e970c7411e7992751a116494cba7c4fb877656527f9a57 \
     --hash=sha256:0ff789ae7d8ddd76d2ac02e7d13bfef6fc4928ac01e1dcaa182be51b6bcc0aaa \
@@ -546,6 +556,8 @@ grpcio==1.56.2 \
     #   -r requirements.in
     #   google-api-core
     #   google-cloud-bigquery
+    #   googleapis-common-protos
+    #   grpc-google-iam-v1
     #   grpcio-status
     #   mozilla-jetstream
 grpcio-status==1.56.2 \
@@ -784,9 +796,9 @@ mozanalysis==2023.5.3 \
     # via
     #   -r requirements.in
     #   mozilla-jetstream
-mozilla-jetstream==2023.6.1 \
-    --hash=sha256:9860814570d57a34bc77dcc1d638dc78c2a1abae2cdc26cb1016e646eae1f622 \
-    --hash=sha256:9eb1110911fe3005a8c6d12bc54ce784a5c92456c96fda7122a93dc774397cb4
+mozilla-jetstream==2023.8.1 \
+    --hash=sha256:89aa5ea27f7883c009cf618eebe9d31b147466efe1fd6c90dfe1ad8601e80df7 \
+    --hash=sha256:e018e99dac85e53821fbb98834cf037b2f83c658cb942251d8746bfe9bb250b7
     # via -r requirements.in
 mozilla-metric-config-parser==2023.6.7 \
     --hash=sha256:1f7b44ba7e4e86d817ee7dfe2b7420b35f4ee6c69d4a30d0e4bc2c48ab17adf9 \
@@ -800,6 +812,7 @@ mozilla-nimbus-schemas==2023.8.1 \
     --hash=sha256:c4f0de05785b7f59442d28ed185165a40fe71baa619402ce3378bc6a956329ab
     # via
     #   -r requirements.in
+    #   mozilla-jetstream
     #   mozilla-metric-config-parser
 msgpack==1.0.5 \
     --hash=sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164 \
@@ -1079,6 +1092,7 @@ proto-plus==1.22.3 \
     --hash=sha256:fdcd09713cbd42480740d2fe29c990f7fbd885a67efc328aa8be6ee3e9f76a6b
     # via
     #   -r requirements.in
+    #   google-cloud-artifact-registry
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-container
@@ -1099,10 +1113,12 @@ protobuf==4.23.4 \
     # via
     #   -r requirements.in
     #   google-api-core
+    #   google-cloud-artifact-registry
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-container
     #   googleapis-common-protos
+    #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
 psutil==5.9.5 \


### PR DESCRIPTION
[jetstream](https://github.com/mozilla/jetstream) logs to the same table as `auto-sizing`, so this adds a value to help differentiate.

Separately, I have already added a column to the bigquery table, and will submit a similar PR to `jetstream`.

Related: https://github.com/mozilla/jetstream/pull/1904