### PR TITLE
change target_prefix back to argo instead of app

### DIFF
--- a/auto_sizing/cli.py
+++ b/auto_sizing/cli.py
@@ -97,11 +97,15 @@ class SerialExecutorStrategy:
         failed = False
         for config in worklist:
             try:
-                sizing = self.sizing_class(self.project_id, self.dataset_id, self.bucket, config)
+                sizing = self.sizing_class(
+                    self.project_id, self.dataset_id, self.bucket, config
+                )
                 sizing.run(datetime.now(tz=pytz.utc).date())
 
             except Exception as e:
-                logger.exception(str(e), exc_info=e, extra={"target": config.target_slug})
+                logger.exception(
+                    str(e), exc_info=e, extra={"target": config.target_slug}
+                )
                 failed = True
 
         return not failed
@@ -155,7 +159,7 @@ class AnalysisExecutor:
                     target_num = 0
                     for app_id in ["firefox_desktop", "firefox_ios", "fenix"]:
                         for target in target_list:
-                            jobs_manifest[f"{app_id}_target_{target_num}"] = {
+                            jobs_manifest[f"argo_target_{target_num}"] = {
                                 "app_id": app_id,
                                 "target_recipe": json.dumps(target),
                             }
@@ -413,7 +417,9 @@ def run_argo(
 ):
     """Runs analysis for the provided date using Argo."""
     if not bucket:
-        raise Exception("A GCS bucket must be provided to save results from runs using Argo.")
+        raise Exception(
+            "A GCS bucket must be provided to save results from runs using Argo."
+        )
 
     strategy = ArgoExecutorStrategy(
         project_id=project_id,
@@ -450,7 +456,9 @@ def export_aggregate_results(project_id, bucket):
     aggregate_and_reupload(project_id=project_id, bucket_name=bucket)
 
 
-def refresh_manifest_file(target_lists_file=TARGET_SETTINGS, manifest_file=RUN_MANIFEST):
+def refresh_manifest_file(
+    target_lists_file=TARGET_SETTINGS, manifest_file=RUN_MANIFEST
+):
     jobs_dict = toml.load(target_lists_file)
     target_list = dict_combinations(jobs_dict, "targets")
     jobs_manifest = {}
@@ -458,7 +466,7 @@ def refresh_manifest_file(target_lists_file=TARGET_SETTINGS, manifest_file=RUN_M
     target_num = 0
     for app_id in ["firefox_desktop", "firefox_ios", "fenix"]:
         for target in target_list:
-            jobs_manifest[f"{app_id}_target_{target_num}"] = {
+            jobs_manifest[f"argo_target_{target_num}"] = {
                 "app_id": app_id,
                 "target_recipe": json.dumps(target),
             }

--- a/auto_sizing/cli.py
+++ b/auto_sizing/cli.py
@@ -97,15 +97,11 @@ class SerialExecutorStrategy:
         failed = False
         for config in worklist:
             try:
-                sizing = self.sizing_class(
-                    self.project_id, self.dataset_id, self.bucket, config
-                )
+                sizing = self.sizing_class(self.project_id, self.dataset_id, self.bucket, config)
                 sizing.run(datetime.now(tz=pytz.utc).date())
 
             except Exception as e:
-                logger.exception(
-                    str(e), exc_info=e, extra={"target": config.target_slug}
-                )
+                logger.exception(str(e), exc_info=e, extra={"target": config.target_slug})
                 failed = True
 
         return not failed
@@ -417,9 +413,7 @@ def run_argo(
 ):
     """Runs analysis for the provided date using Argo."""
     if not bucket:
-        raise Exception(
-            "A GCS bucket must be provided to save results from runs using Argo."
-        )
+        raise Exception("A GCS bucket must be provided to save results from runs using Argo.")
 
     strategy = ArgoExecutorStrategy(
         project_id=project_id,
@@ -456,9 +450,7 @@ def export_aggregate_results(project_id, bucket):
     aggregate_and_reupload(project_id=project_id, bucket_name=bucket)
 
 
-def refresh_manifest_file(
-    target_lists_file=TARGET_SETTINGS, manifest_file=RUN_MANIFEST
-):
+def refresh_manifest_file(target_lists_file=TARGET_SETTINGS, manifest_file=RUN_MANIFEST):
     jobs_dict = toml.load(target_lists_file)
     target_list = dict_combinations(jobs_dict, "targets")
     jobs_manifest = {}


### PR DESCRIPTION
I accidentally committed an unrelated change to the target slug prefix in #67. That probably won't work, and in any case we should make that change separately and ideally with some testing.