### PR TITLE
Add descriptions of targets to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ pip install .
 ### Updating Pre-computed Targets or Parameters
 `auto_sizing/data/target_lists.toml` contains the list of targets and configuration parameters (including metrics). Update this file to change the set of targets to pre-compute.
 
+Currently, pre-computed size calculation supports targeting clients on locale, country, channel, or user type, which includes new or existing clients. New clients are defined
+as clients whose first seen date is during the 7 day enrollment period of the size calculation analysis; existing clients are defined as clients whose first seen date was at least
+28 days before the first date of enrollment in the size calculation analysis. For any target dimension, the string `'all'` can be included to omit that condition from client selection.
+
 *Note* that `locale` is an array of stringified tuples, each of which is a discrete set of locale combinations. In other words, if you include `EN-US` and `EN-UK` in the list separately, there would be no pre-computed sizing for the combination of `EN-US, EN-UK`. To include combinations, add `"('EN-US', 'EN-UK')"` as its own entry in the list.
 
 #### Refresh Manifest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This tool automatically calculates sizing for experiments.
 
+Currently, pre-computed size calculation supports targeting clients on locale, country, channel, or user type, which includes new or existing clients. New clients are defined
+as clients whose first seen date is during the 7 day enrollment period of the size calculation analysis; existing clients are defined as clients whose first seen date was at least
+28 days before the first date of enrollment in the size calculation analysis. For any target dimension, the string `'all'` can be included to omit that condition from client selection.
+
 
 ## Development Info
 ### Local Installation
@@ -17,10 +21,6 @@ pip install .
 
 ### Updating Pre-computed Targets or Parameters
 `auto_sizing/data/target_lists.toml` contains the list of targets and configuration parameters (including metrics). Update this file to change the set of targets to pre-compute.
-
-Currently, pre-computed size calculation supports targeting clients on locale, country, channel, or user type, which includes new or existing clients. New clients are defined
-as clients whose first seen date is during the 7 day enrollment period of the size calculation analysis; existing clients are defined as clients whose first seen date was at least
-28 days before the first date of enrollment in the size calculation analysis. For any target dimension, the string `'all'` can be included to omit that condition from client selection.
 
 *Note* that `locale` is an array of stringified tuples, each of which is a discrete set of locale combinations. In other words, if you include `EN-US` and `EN-UK` in the list separately, there would be no pre-computed sizing for the combination of `EN-US, EN-UK`. To include combinations, add `"('EN-US', 'EN-UK')"` as its own entry in the list.
 


### PR DESCRIPTION
Adds descriptions of the dimensions available for targeting for pre-computed sizes to README.md. Included in that description are the definitions of new and existing clients, as well as the option to omit dimensions from size calculation.