### PR TITLE
chore: update gcp-gcr orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.15.1
+  gcp-gcr: circleci/gcp-gcr@0.16.10
 
 jobs:
   build:

--- a/setup.py
+++ b/setup.py
@@ -10,21 +10,20 @@ test_dependencies = [
     "coverage",
     "isort",
     "jsonschema",
-    "pytest<8",
+    "mypy",
+    "pytest",
     "pytest-black",
     "pytest-cov",
     "pytest-flake8",
-    "mypy",
     "types-futures",
-    "types-pkg-resources",
     "types-protobuf",
     "types-pytz",
     "types-PyYAML",
     "types-requests",
+    "types-setuptools",
     "types-six",
     "types-toml",
 ]
-
 extras = {
     "testing": test_dependencies,
 }
@@ -34,7 +33,7 @@ setup(
     author="Mozilla Corporation",
     author_email="fx-data-dev@mozilla.org",
     description="Runs automatic sample size calc",
-    url="https://github.com/m-d-bowerman/auto-sizing",
+    url="https://github.com/mozilla/auto-sizing",
     packages=[
         "auto_sizing",
         "auto_sizing.logging",


### PR DESCRIPTION
Getting an error about base image not existing when CI tries to run the build-and-push-docker step. Guessing this is because the orb is out of date, so going to bump to the latest.